### PR TITLE
specify bash rather than sh when using $PIPESTATUS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ SHELL := bash
 
 RUN = poetry run
 # get values from about.yaml file
-SCHEMA_NAME = $(shell sh ./utils/get-value.sh name)
-SOURCE_SCHEMA_PATH = $(shell sh ./utils/get-value.sh source_schema_path)
+SCHEMA_NAME = $(shell bash ./utils/get-value.sh name)
+SOURCE_SCHEMA_PATH = $(shell bash ./utils/get-value.sh source_schema_path)
 SRC = src
 DEST = project
 PYMODEL = $(SRC)/$(SCHEMA_NAME)/datamodel

--- a/utils/get-value.sh
+++ b/utils/get-value.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # get the value of a key in the about.yaml file
 # https://stackoverflow.com/questions/1221833/pipe-output-and-capture-exit-status-in-bash
 grep $1 about.yaml | sed "s/$1:[[:space:]]//" ; test ${PIPESTATUS[0]} -eq 0


### PR DESCRIPTION
$PIPESTATUS is a bashism-- systems with dash or another non-bash
POSIX shell at /bin/sh would give an error for bad substitution if
trying to access this variable.