### PR TITLE
Ignore `docs/` only in the repository root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-docs/
+/docs/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Fixes #14. Without this, src/docs/about.md ends up being gitignored,
and the absence of this file prevents `make gendoc` (and dependent tasks)
from working