### PR TITLE
Add template for `pyproject.toml`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ git-init:
 	git init
 git-add:
 	git add .gitignore .github Makefile LICENSE *.md examples utils about.yaml mkdocs.yml poetry.lock project.Makefile pyproject.toml src/linkml/*yaml src/*/datamodel/*py src/data
-	git add $(patsubst %, project/%, $(PROJECT_FOLDERS))
+	git add project
 git-commit:
 	git commit -m 'Initial commit' -a
 git-status:

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "{{name}}"
+version = "0.1.0"
+description = "{{description}}"
+authors = ["{{author}}"]
+license = "MIT"
+include = ["README.md", "src/linkml", "project"]
+
+[tool.poetry.dependencies]
+python = "^3.9"
+linkml-runtime = "^1.2.15"
+mkdocs-mermaid2-plugin = "^0.6.0"
+
+[tool.poetry.dev-dependencies]
+linkml = "^1.2.6"
+mkdocs-material = "^8.2.8"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This adds a template for `pyproject.toml` in the generated project. It relies on an `author` variable in the Jinja context which is being added by the changes in https://github.com/linkml/linkml/pull/801. 

I also ran into an issue where `make setup` in the generated project was failing because of a missing `project/excel` directory. It seemed sensible to me to just `git add` the entire `project` directory instead of enumerating `project` subdirectories. 

Fixes #22 