### PR TITLE
Use pipx to run workspace generation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ NOTE: You don't need to directly use this repository directly!
 
 ## Prerequisites
 
-This repository is designed to be used via the `linkms-ws` script in the 
+This repository is designed to be used via the `linkml-ws` script in the 
 [`linkml` package](https://github.com/linkml/linkml). We encourage running 
 that script via `pipx`. If you haven't already, follow 
 [these instructions](https://pypa.github.io/pipx/#install-pipx) to install `pipx`. 
+
+The project that `linkml-ws` generates uses [Poetry](https://python-poetry.org/) 
+for dependency management. So be sure to have that 
+[installed](https://python-poetry.org/docs/#installation), too.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,17 @@ _A template for LinkML projects_
 
 NOTE: You don't need to directly use this repository directly!
 
-Instead:
+## Prerequisites
 
- * [install poetry](https://python-poetry.org/docs/)
- * [install linkml](https://linkml.io/linkml/intro/install.html)
- * run `linkml-ws new`
+This repository is designed to be used via the `linkms-ws` script in the 
+[`linkml` package](https://github.com/linkml/linkml). We encourage running 
+that script via `pipx`. If you haven't already, follow 
+[these instructions](https://pypa.github.io/pipx/#install-pipx) to install `pipx`. 
 
-## Example:
-
+## Example
 
 ```
-mkdir ~/my-projects
-cd ~/my-projects
-pip install linkml
-linkml-ws new my-project-name
+pipx run --spec linkml linkml-ws new my-project-name
 cd my-project-name
 # edit src/linkml/my-project-name
 make setup


### PR DESCRIPTION
These changes replace using `pip` to install `linkml` and then calling `linkml-ws` with a single `pipx` command. This will keep `linkml` out of the users global environment and ensure the latest version of `linkml` is always used. Pointers for getting `pipx` setup are also provided, as well as a bit of clarification about the role of Poetry.